### PR TITLE
Fix output_options.yaml

### DIFF
--- a/src/config_files/output_options.yaml
+++ b/src/config_files/output_options.yaml
@@ -13,7 +13,8 @@ ffmpeg:
       -pix_fmt: rgba64le
       -vsync: "cfr"
       -crf: 15
-      -vf: noise=c0s=8:c0f=u
+      -vf:
+        - noise=c0s=8:c0f=u
 
   convert_video_to_gif:
     output_options:
@@ -56,7 +57,6 @@ waifu2x_converter:
     --silent: true
 
 waifu2x_caffe:
-
   output_options:
     -batch_size: null
     -crop_size: null


### PR DESCRIPTION
Recently updated version of this file is giving me the following error:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "threading.py", line 954, in _bootstrap_inner
  File "dandere2x\__init__.py", line 56, in run
  File "dandere2x\dandere2x_service\service_types\singleprocess_service.py", line 60, in run
  File "dandere2x\dandere2x_service\service_types\singleprocess_service.py", line 40, in _pre_process
  File "dandere2x\dandere2x_service\service_types\dandere2x_service_interface.py", line 78, in _check_and_fix_resolution
  File "dandere2x\dandere2xlib\wrappers\ffmpeg\ffmpeg.py", line 130, in append_resize_filter_to_pre_process
AttributeError: 'str' object has no attribute 'append'
```

Quick comparison with the old version of the suggested this syntactic YAML change.