### PR TITLE
Fix Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt install -y --no-install-recommends ffmpeg nvidia-driver-440 python3.8 li
 
 # Needed Library for Building Dandere2x (this will be removed later)
 RUN apt-get install -y cmake
+RUN apt-get install -y curl
 RUN apt-get install -y git-core
 RUN apt-get install -y build-essential
 RUN apt-get install -y libgl1-mesa-glx


### PR DESCRIPTION
Currently, trying to build a Docker image will appear to succeed, but won't actually work when you attempt to upscale a video due to missing binaries in `externals`. This is because the script in `src/linux_setup.sh` uses curl to download them, which was not installed in the base image. 