### PR TITLE
Fix: unix_setup.sh problems

### DIFF
--- a/src/unix_setup.sh
+++ b/src/unix_setup.sh
@@ -48,7 +48,7 @@ else
 fi
 unzip waifu2x-ncnn-vulkan.zip
 rm waifu2x-ncnn-vulkan.zip
-find . -maxdepth 1 -name "waifu2x*" -maxdepth 1 -exec mv {} waifu2x-ncnn-vulkan \;
+find . -maxdepth 1 -name "waifu2x*" -exec mv {} waifu2x-ncnn-vulkan \;
 
 
 # Waifu2x NCNN Vulkan

--- a/src/unix_setup.sh
+++ b/src/unix_setup.sh
@@ -48,11 +48,11 @@ else
 fi
 unzip waifu2x-ncnn-vulkan.zip
 rm waifu2x-ncnn-vulkan.zip
-find . -name 'waifu2x*' -maxdepth 1 -exec mv {} waifu2x-ncnn-vulkan \;
+find . -maxdepth 1 -name "waifu2x*" -maxdepth 1 -exec mv {} waifu2x-ncnn-vulkan \;
 
 
 # Waifu2x NCNN Vulkan
-if [[ $OS == 'linux' ]]; then
+if [[ $OS == "linux" ]]; then
     echo -e "installing latest realsr-ncnn-vulkan for linux\n"
     curl -s https://api.github.com/repos/nihui/realsr-ncnn-vulkan/releases/latest | sed -n 's/.*"browser_download_url": "\(.*ubuntu\.zip\)".*/\1/p' | xargs -n1 curl -o realsr-ncnn-vulkan.zip -OL
 else
@@ -62,12 +62,12 @@ fi
 
 unzip realsr-ncnn-vulkan.zip
 rm realsr-ncnn-vulkan.zip
-find . -name 'realsr*' -maxdepth 1 -exec mv {} realsr-ncnn-vulkan \;
+find . -maxdepth 1 -name "realsr*" -exec mv {} realsr-ncnn-vulkan \;
 
 # create executable_config file
 # printf "ffmpeg: \"$ffmpeg\"\nffprobe: \"$ffprobe\"\ndandere2x_cpp: \"$dandere2x_cpp\"\nwaifu2x_vulkan: \"$waifu2x_vulkan\"\nwaifu2x_converter_cpp: \"$waifu2x_converter_cpp\"\nwaifu2x_caffe: \"$waifu2x_caffe\"\nrealsr_ncnn_vulkan: \"$realsr_vulkan\"" > ../config_files/executable_paths.yaml
 
 # create workspace folder (this needs to exist I think?)
-cd .. 
+cd ..
 mkdir -p workspace
 echo "setup successful. install the requirements with pip3 install -r requirements.txt, preferably in a a virtual environment, then run python3 main.py"

--- a/src/unix_setup.sh
+++ b/src/unix_setup.sh
@@ -1,10 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
+OS='linux'
 
-
-if [[ $OSTYPE == 'darwin'* ]]; then
+if [[ $OSTYPE =~ "darwin" ]]; then
     OS='macos'
-else
-    OS='ubuntu'
 fi
 
 # Requirements...
@@ -19,7 +17,7 @@ if ! command -v ffmpeg > /dev/null 2>&1; then
 fi
 
 # Create d2x-cpp binary
-cd ../dandere2x_cpp
+cd ../dandere2x_cpp || exit 1
 cmake CMakeLists.txt
 make
 
@@ -30,41 +28,41 @@ if ! test -f "$FILE"; then
 fi
 
 #  get into the src folder from dandere2x_cpp
-cd ../src
+cd ../src || exit 1
 
 # create the externals folder and move over the recently made d2x_cpp binary
 mkdir -p externals
 mv ../dandere2x_cpp/dandere2x_cpp ./externals/dandere2x_cpp
 
 # download waifu2x-ncnn-vulkan and extract it the way d2x expects it
-cd externals
+cd externals || exit 1
 
 
-echo "installing latest waifu2x-ncnn-vulkan"
-echo ""
 # download latest waifu2x-ncnn-vulkan and extract it to externals
-if [[ $OS == 'ubuntu' ]]; then
+if [[ $OS == 'linux' ]]; then
+    echo -e "installing latest waifu2x-ncnn-vulkan for linux\n"
     curl -s https://api.github.com/repos/nihui/waifu2x-ncnn-vulkan/releases/latest | sed -n 's/.*"browser_download_url": "\(.*ubuntu\.zip\)".*/\1/p' | xargs -n1 curl -o waifu2x-ncnn-vulkan.zip -OL
 else
+    echo -e "installing latest waifu2x-ncnn-vulkan for mac\n"
     curl -s https://api.github.com/repos/nihui/waifu2x-ncnn-vulkan/releases/latest | sed -n 's/.*"browser_download_url": "\(.*macos\.zip\)".*/\1/p' | xargs -n1 curl -o waifu2x-ncnn-vulkan.zip -OL
 fi
 unzip waifu2x-ncnn-vulkan.zip
 rm waifu2x-ncnn-vulkan.zip
-mv $(find . -name 'waifu2x*' -maxdepth 1) waifu2x-ncnn-vulkan
+find . -name 'waifu2x*' -maxdepth 1 -exec mv {} waifu2x-ncnn-vulkan \;
 
 
-# Waifu2x NCNN Vulkan 
-echo "installing latest realsr-ncnn-vulkan"
-echo ""
-if [[ $OS == 'ubuntu' ]]; then
+# Waifu2x NCNN Vulkan
+if [[ $OS == 'linux' ]]; then
+    echo -e "installing latest realsr-ncnn-vulkan for linux\n"
     curl -s https://api.github.com/repos/nihui/realsr-ncnn-vulkan/releases/latest | sed -n 's/.*"browser_download_url": "\(.*ubuntu\.zip\)".*/\1/p' | xargs -n1 curl -o realsr-ncnn-vulkan.zip -OL
 else
+    echo -e "installing latest realsr-ncnn-vulkan for mac\n"
     curl -s https://api.github.com/repos/nihui/realsr-ncnn-vulkan/releases/latest | sed -n 's/.*"browser_download_url": "\(.*macos\.zip\)".*/\1/p' | xargs -n1 curl -o realsr-ncnn-vulkan.zip -OL
 fi
 
 unzip realsr-ncnn-vulkan.zip
 rm realsr-ncnn-vulkan.zip
-mv $(find . -name 'realsr*' -maxdepth 1) realsr-ncnn-vulkan
+find . -name 'realsr*' -maxdepth 1 -exec mv {} realsr-ncnn-vulkan \;
 
 # create executable_config file
 # printf "ffmpeg: \"$ffmpeg\"\nffprobe: \"$ffprobe\"\ndandere2x_cpp: \"$dandere2x_cpp\"\nwaifu2x_vulkan: \"$waifu2x_vulkan\"\nwaifu2x_converter_cpp: \"$waifu2x_converter_cpp\"\nwaifu2x_caffe: \"$waifu2x_caffe\"\nrealsr_ncnn_vulkan: \"$realsr_vulkan\"" > ../config_files/executable_paths.yaml


### PR DESCRIPTION
This script didn't even function on my machine, making at least the `sh` vs `bash` change necessary. Cleaned up a few other things as well.

  - In POSIX sh, `[[ ]]` is undefined. 
  - Use env to properly locate and use bash. 
  - If any of the `cd` commands fail, exit with status 1.
  - Use the exec flag in `find` to move things instead of in-lining an eval
  - Misc. cleanup